### PR TITLE
Fix: Use absolute path for dynamic module imports in ZForgeBuilder

### DIFF
--- a/builder/core/builder.py
+++ b/builder/core/builder.py
@@ -187,8 +187,8 @@ class ZForgeBuilder:
 
         # Import the module
         try:
-            module_path = f"modules.{module_name.lower()}"
-            module = importlib.import_module(module_path, package="builder")
+            module_path = f"builder.modules.{module_name.lower()}"
+            module = importlib.import_module(module_path)
 
             # Create instance
             class_name = module_name


### PR DESCRIPTION
Changed the dynamic module import in `builder.core.builder.ZForgeBuilder._execute_module` to use an absolute path (e.g., `builder.modules.modulename`) instead of a package-relative path (`modules.modulename` with `package="builder"`).

The previous package-relative import was still resulting in a "No module named 'modules'" error in the `build-iso.sh` script's execution environment. Using an absolute path from the top-level `builder` package (which is in PYTHONPATH) should be more robust and resolve this issue.

This change, along with the prior addition of `builder/modules/__init__.py`, is intended to ensure correct module loading during the ISO build process.