### PR TITLE
feat: Configure R320 and R730xd server builds

### DIFF
--- a/build_spec.yml
+++ b/build_spec.yml
@@ -36,7 +36,7 @@ zfs_config:
   enable_encryption: true
   default_compression: lz4
   # R730xd has more RAM, can use larger ARC
-  arc_max_size: "32G"
+  arc_max_size: "16G"  # Updated based on user feedback
   # Server optimizations
   prefetch_disable: false  # Enable prefetch for better read perf
   zio_delay_max: 5000
@@ -138,10 +138,10 @@ iso_customization:
 security_config:
   security_hardening_profile: "server" # Options: "baseline", "server", or "none" (or omit for none)
 
-# Telemetry Configuration
-telemetry_config:
-  # Define the endpoint URL where telemetry data should be sent.
-  # If commented out or empty, the TelemetryJob module will not attempt to send data.
-  telemetry_endpoint_url: "https_example.com/telemetry_test_r730xd" # Placeholder URL
-  # User consent is handled via the TelemetryConsent UI module in Calamares.
-  # This URL is only used if the user explicitly opts-in during installation.
+# Telemetry Configuration (Disabled based on user feedback)
+# telemetry_config:
+#   # Define the endpoint URL where telemetry data should be sent.
+#   # If commented out or empty, the TelemetryJob module will not attempt to send data.
+#   telemetry_endpoint_url: "https_example.com/telemetry_test_r730xd" # Placeholder URL
+#   # User consent is handled via the TelemetryConsent UI module in Calamares.
+#   # This URL is only used if the user explicitly opts-in during installation.

--- a/calamares/modules/zfspooldetect/module.desc
+++ b/calamares/modules/zfspooldetect/module.desc
@@ -1,0 +1,11 @@
+# zfspooldetect/module.desc
+---
+type:           "job"
+name:           "ZFS Pool Detection"
+moduleVersion:  "1.0.0"
+description:    "Detects existing ZFS pools on the system to make them available for installation."
+interface:      "python"
+script:         "main.py"
+# No specific module dependencies, should run early in the partitioning phase.
+# Consider if it needs to run before 'partition' or as part of it.
+# For now, assuming it's a standalone job that makes pools available to subsequent modules.

--- a/calamares/modules/zfsrootselect/module.desc
+++ b/calamares/modules/zfsrootselect/module.desc
@@ -1,0 +1,12 @@
+# zfsrootselect/module.desc
+---
+type:           "job"
+name:           "ZFS Root Filesystem Selection"
+moduleVersion:  "1.0.0"
+description:    "Allows selection or creation of the ZFS root filesystem for installation."
+interface:      "python"
+script:         "main.py"
+requiredModules:
+  - "zfspooldetect"  # Requires pools to be detected first
+# This module would typically interact with partitioning and mount setup.
+# It might need to run after initial disk partitioning but before actual package installation.

--- a/config/r320/r320_build_spec.yml
+++ b/config/r320/r320_build_spec.yml
@@ -1,0 +1,137 @@
+# Z-Forge Build Configuration for PowerEdge R320
+builder_config:
+  debian_release: bookworm
+  kernel_version: latest
+  output_iso_name: zforge-r320-proxmox-v3.iso
+  enable_debug: true
+  workspace_path: /tmp/zforge_workspace
+  cache_packages: true
+
+proxmox_config:
+  version: latest
+  minimal_install: true
+  include_packages:
+    - proxmox-ve
+    - pve-kernel-6.8 # Consider if a specific older kernel is better for R320
+    - zfs-dkms
+    - zfsutils-linux
+    - pve-zsync
+    # Dell PowerEdge R320 relevant packages
+    - ipmitool
+    - openipmi
+    - lm-sensors
+    - nvme-cli # NVMe confirmed for R320
+    - ethtool
+    - fio
+    - smartmontools
+    # RAID tools for R320 might include perccli or sas2ircu/sas3ircu depending on controller
+    # Adding common ones, but this needs verification for typical R320 controllers (e.g., H310, H710)
+    - perccli
+    - sas2ircu
+
+zfs_config:
+  version: latest
+  build_from_source: true
+  enable_encryption: true
+  default_compression: lz4
+  # R320 likely has less RAM than R730xd
+  arc_max_size: "16G" # Updated based on user feedback
+  # Server optimizations
+  prefetch_disable: false  # Enable prefetch for better read perf
+  zio_delay_max: 5000
+
+bootloader_config:
+  primary: zfsbootmenu
+  enable_opencore: true # Enabled as per user feedback for NVMe
+  enable_two_stage: false # Ensured false as per user feedback
+  opencore_drivers:
+    - NvmExpressDxe.efi # Added as per user feedback for NVMe
+    - OpenRuntime.efi
+  # Dell PowerEdge R320 PCIe path configuration for NVMe
+  # Using placeholder as specific path was not provided. User should verify this.
+  nvme_pcie_path: "PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)"
+  uefi_mode: true # R320 should support UEFI
+
+dracut_config:
+  modules:
+    - zfs
+    - systemd
+    - network
+  compress: zstd
+  hostonly: true
+  # Add serial console support, common for servers
+  kernel_cmdline: "root=zfs:AUTO console=tty0 console=ttyS0,115200n8 mitigations=auto,nosmt"
+  extra_drivers:
+    # NVMe driver for R320 (NVMe confirmed)
+    - nvme
+    # Dell PERC RAID controller drivers - R320 might use H310/H710 (mpt2sas)
+    - mpt2sas
+    - megaraid_sas # For H710 or similar
+    # Network drivers for Dell PowerEdge R320 (commonly Broadcom or Intel)
+    - tg3 # Broadcom
+    - igb # Intel
+    - bnx2 # Broadcom NetXtreme II
+
+# Dell PowerEdge R320 specific configuration
+dell_r320_config:
+  enable_serial_console: true
+  serial_port: "ttyS0"
+  serial_speed: 115200
+  enable_idrac: true
+  ipmi_settings:
+    enable_sol: true
+    sol_speed: 115200
+  raid_monitoring: true # If applicable RAID controller is present
+  # NVMe settings - R320 confirmed to use NVMe.
+  nvme_settings:
+    io_timeout: 4294967295 # Standard default
+    max_host_mem_size_mb: 512 # R320 may have less RAM for controller, adjust if needed
+    scheduler: "none" # Often recommended for NVMe
+    read_ahead_kb: 128 # Common default, adjust as needed
+    nr_requests: 1024 # Common default, adjust as needed
+  cpu_governor: "performance"
+  system_memory:
+    swappiness: 10 # May need more swap with less RAM
+    dirty_ratio: 15
+    min_free_kbytes: 262144 # Adjusted for potentially less RAM than R730xd
+
+# Include R320 specific post-install scripts if they exist
+# Create these if needed, or remove if not applicable
+post_install_scripts:
+  - config/r320/r320_post_install.sh
+  # - config/r320/r320_nvme_tune.sh # If NVMe is used
+
+modules:
+  - name: WorkspaceSetup
+    enabled: true
+  - name: Debootstrap
+    enabled: true
+  - name: KernelAcquisition
+    enabled: true
+  - name: ZFSBuild
+    enabled: true
+  - name: DracutConfig
+    enabled: true
+  - name: ProxmoxIntegration
+    enabled: true
+  - name: LiveEnvironment
+    enabled: true
+  - name: CalamaresIntegration
+    enabled: true
+  # Placeholder for a generic or R320 specific optimization module
+  - name: DellServerOptimize
+    enabled: true
+  - name: ISOGeneration
+    enabled: true
+
+# Custom ISO Build Versioning
+iso_customization:
+  iso_version: "r320-dev-build-$(date +%Y%m%d)"
+
+# Security Hardening Configuration
+security_config:
+  security_hardening_profile: "server"
+
+# Telemetry Configuration (Disabled based on user feedback)
+# telemetry_config:
+#  telemetry_endpoint_url: "https_example.com/telemetry_test_r320" # Different endpoint for R320


### PR DESCRIPTION
This commit introduces the following changes:

- Adds module.desc files for zfspooldetect and zfsrootselect Calamares modules.
- Creates a new build_spec.yml for the Dell R320 server (`config/r320/r320_build_spec.yml`), tailored for its hardware profile including NVMe support.
- Updates the existing R730xd build_spec.yml (`build_spec.yml`) and the new R320 build_spec.yml:
    - Sets ZFS ARC max size to 16GB for both.
    - Ensures ZFS prefetch is enabled for both.
    - Confirms two-stage bootloader is disabled for both.
    - Enables OpenCore with NvmExpressDxe driver for NVMe boot on both.
    - Sets a placeholder NVMe PCIe path for R320 and confirms path for R730xd.
    - Disables telemetry for both configurations.
- Adjusts package lists and Dracut drivers in R320 spec for its hardware (including NVMe).