### PR TITLE
feat: Implement KDE desktop with dark theme and conditional headless …

### DIFF
--- a/build_spec.yml
+++ b/build_spec.yml
@@ -29,6 +29,10 @@ proxmox_config:
     - ethtool
     - fio
     - smartmontools
+    # Packages for KDE theme configuration and utilities
+    - "kwriteconfig5" # From kwriteconfig package, ensure it's available
+    - "breeze" # For Breeze themes, including Breeze Dark (usually part of kde-standard)
+    - "plasma-desktop-data" # For default theme data, if needed explicitly
 
 zfs_config:
   version: latest
@@ -124,6 +128,8 @@ modules:
   - name: LiveEnvironment
     enabled: true
   - name: CalamaresIntegration
+    enabled: true
+  - name: KDEThemeConfig # Added KDEThemeConfig module
     enabled: true
   - name: DellR730xdOptimize
     enabled: true

--- a/builder/core/builder.py
+++ b/builder/core/builder.py
@@ -102,6 +102,11 @@ class ZForgeBuilder:
             lockfile_path = Path("build_spec.lock")
             lockfile = BuildLockfile(lockfile_path)
 
+        # Ensure modules_path is set for dynamic loading
+        if not hasattr(self, 'modules_path') or not self.modules_path:
+             self.modules_path = Path(__file__).parent.parent / "modules"
+
+
         # Track progress
         results = {}
         resume_data = {}
@@ -197,25 +202,62 @@ class ZForgeBuilder:
 
         # Import the module
         try:
-            module_file_name = _camel_to_snake(module_name)
-            module_path = f"builder.modules.{module_file_name}"
-            module = importlib.import_module(module_path)
+            module_file_name = _camel_to_snake(module_name) # e.g., KDEThemeConfig -> kde_theme_config
 
-            # Create instance
-            class_name = module_name
+            # Construct path to module file
+            module_file_path = self.modules_path / f"{module_file_name}.py"
+
+            if not module_file_path.exists():
+                return {
+                    'status': 'error',
+                    'error': f"Module file {module_file_path} not found for module {module_name}"
+                }
+
+            # Dynamically load the module from its file path
+            spec = importlib.util.spec_from_file_location(f"builder.modules.{module_file_name}", module_file_path)
+            if spec is None:
+                 return {
+                    'status': 'error',
+                    'error': f"Could not create module spec for {module_name} from {module_file_path}"
+                }
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module) # type: ignore
+
+            # Create instance - class name is expected to be CamelCase version of module_name
+            class_name = module_name # Assumes module_name is already CamelCase, e.g., "KDEThemeConfig"
+
+            # A common pattern is that the module name in config (e.g., "KDEThemeConfig")
+            # directly matches the class name.
             if not hasattr(module, class_name):
-                class_name = ''.join(
-                    word.title() for word in module_name.split('_')
-                )
+                # Fallback if module_name in config was snake_case (e.g., "kde_theme_config")
+                # then convert it to CamelCase for the class name.
+                class_name_camel = "".join(word.capitalize() for word in module_name.split('_'))
+                if hasattr(module, class_name_camel):
+                    class_name = class_name_camel
+                else:
+                    # Try simple title casing if module_name was all lower or mixed but not snake
+                    class_name_title = module_name.title().replace("_", "")
+                    if hasattr(module, class_name_title):
+                        class_name = class_name_title
+                    else:
+                         return {
+                            'status': 'error',
+                            'error': f"Class {class_name} (or {class_name_camel} or {class_name_title}) not found in module {module_name} at {module_file_path}"
+                        }
 
-            if hasattr(module, class_name):
-                module_instance = getattr(module, class_name)(
-                    self.workspace,
-                    self.config.data
-                )
+            module_instance = getattr(module, class_name)(
+                self.workspace,
+                self.config.data
+            )
 
-                # Execute module
-                result = module_instance.execute(resume_data)
+            # Execute module
+            if hasattr(module_instance, 'execute'):
+                result = module_instance.execute(resume_data) # type: ignore
+            else:
+                return {
+                    'status': 'error',
+                    'error': f"Module {module_name} instance does not have an execute method."
+                }
 
                 # Record to lockfile if provided
                 if lockfile and result.get('status') == 'success':

--- a/builder/modules/calamares_integration.py
+++ b/builder/modules/calamares_integration.py
@@ -131,19 +131,24 @@ class CalamaresIntegration:
         # List of packages to install:
         # - calamares: The installer framework.
         # - calamares-settings-debian: Debian-specific configurations/modules for Calamares.
-        # - xfce4 & xfce4-terminal: A lightweight desktop environment and terminal.
-        # - lightdm & lightdm-gtk-greeter: A display manager and greeter for XFCE.
+        # - kde-standard & sddm: KDE Plasma desktop and SDDM display manager. (Replaces XFCE/LightDM)
+        # - konsole: KDE's terminal emulator.
         # - firefox-esr: A web browser for the live environment.
-        # - network-manager-gnome: For network configuration in the live environment.
-        # - gparted: Partition editor (useful tool, Calamares might use its libs or own partitioner).
+        # - network-manager: For network configuration in the live environment (plasma-nm for applet).
+        # - gparted: Partition editor.
         # - python3-pyqt5, python3-yaml, python3-jsonschema: Common dependencies for Calamares modules.
         packages_to_install: List[str] = [
             "calamares", "calamares-settings-debian",
-            "xfce4", "xfce4-terminal", "lightdm", "lightdm-gtk-greeter",
-            "firefox-esr", "network-manager-gnome",
+            # "kde-standard", "sddm", # Already installed in live_environment.py
+            "konsole", # KDE's terminal
+            "firefox-esr", "network-manager", "plasma-nm", # Network management with KDE applet
             "gparted", "vim", "nano", "htop", # Standard system utilities
             "python3-pyqt5", "python3-yaml", "python3-jsonschema"
         ]
+        # Ensure no XFCE or LightDM packages are installed if they were in a previous version of this list
+        # For example, by explicitly removing them or ensuring they are not in `packages_to_install`.
+        # Since kde-standard and sddm are now installed by live_environment.py,
+        # we only need to ensure Calamares and its direct GUI dependencies are here.
 
         # Using bash -c for a multi-line command to ensure proper execution order in chroot.
         install_script: str = f"""
@@ -432,107 +437,121 @@ Item {
 
     def _setup_live_desktop_environment(self) -> None:
         """
-        Configure the lightweight XFCE desktop environment for the live installer.
-        This typically involves setting up LightDM for auto-login to a specific user
-        (e.g., a 'live' user, or 'root' for simplicity in installer environments).
+        Configure the KDE Plasma desktop environment for the live installer.
+        This involves setting up SDDM for auto-login and ensuring Calamares
+        can be launched automatically or easily by the user.
         """
-        self.logger.info("Setting up live desktop environment (LightDM auto-login for XFCE)...")
+        self.logger.info("Setting up live KDE desktop environment (SDDM auto-login)...")
 
-        # Configure LightDM for auto-login as root to the XFCE session.
-        # This is common for live installer environments to simplify user experience.
-        # WARNING: Auto-login as root is generally insecure for a persistent system
-        # but acceptable for a transient live installer environment.
-        lightdm_conf_content: str = """
-[Seat:*]
-autologin-guest=false
-autologin-user=root  # Auto-login as root user
-autologin-user-timeout=0 # No timeout for auto-login
-autologin-session=xfce # Automatically start XFCE session
+        # Configure SDDM for auto-login as root to the Plasma session.
+        # WARNING: Auto-login as root is insecure for a persistent system but acceptable for a live installer.
+        sddm_conf_dir: Path = self.chroot_path / "etc/sddm.conf.d"
+        sddm_conf_dir.mkdir(parents=True, exist_ok=True)
+        sddm_conf_content: str = """[Autologin]
+User=root
+Session=plasma.desktop
+Relogin=false
 
-[Security]
-allow-root=true # Explicitly allow root login via LightDM (may be needed)
-"""
-        lightdm_conf_path: Path = self.chroot_path / "etc/lightdm/lightdm.conf"
-        lightdm_conf_path.parent.mkdir(parents=True, exist_ok=True) # Ensure /etc/lightdm exists
-        lightdm_conf_path.write_text(lightdm_conf_content)
-        self.logger.info(f"LightDM configuration for auto-login written to {lightdm_conf_path}")
+[Users]
+HideUsers=
+RememberLastUser=true
+RememberLastSession=true
 
-        # Create a default .xinitrc for the root user to start XFCE if LightDM fails
+[General]
+DisplayServer=x11
+""" # Using X11 for broader compatibility in live env, Wayland could be an option.
+        sddm_autologin_conf_path: Path = sddm_conf_dir / "autologin.conf"
+        sddm_autologin_conf_path.write_text(sddm_conf_content)
+        self.logger.info(f"SDDM configuration for auto-login written to {sddm_autologin_conf_path}")
+
+        # Create a default .xinitrc for the root user to start KDE Plasma if SDDM fails
         # or if starting X manually (e.g., via startx).
-        xinitrc_content: str = """#!/bin/bash
-# Start XFCE session
-exec startxfce4
+        # For KDE, `startplasma-x11` or `startplasma-wayland` is used.
+        xinitrc_content: str = """#!/bin/sh
+# Start KDE Plasma session (X11)
+export DESKTOP_SESSION=plasma
+export XDG_SESSION_DESKTOP=KDE
+export XDG_CURRENT_DESKTOP=KDE
+exec startplasma-x11
 """
         xinitrc_path: Path = self.chroot_path / "root/.xinitrc"
         xinitrc_path.write_text(xinitrc_content)
         xinitrc_path.chmod(0o755) # Make it executable.
-        self.logger.info(f"Root user .xinitrc created at {xinitrc_path}")
-        self.logger.info("Live desktop environment setup for Calamares completed.")
+        self.logger.info(f"Root user .xinitrc for KDE Plasma created at {xinitrc_path}")
+
+        # Autostart Calamares in KDE session
+        autostart_dir_chroot: Path = self.chroot_path / "root/.config/autostart" # User-specific autostart
+        # For system-wide autostart: /etc/xdg/autostart
+        # Since we auto-login as root, user-specific is fine.
+        autostart_dir_chroot.mkdir(parents=True, exist_ok=True)
+
+        calamares_autostart_content: str = f"""[Desktop Entry]
+Type=Application
+Name=Z-Forge Installer
+Comment=Launch Z-Forge Proxmox VE Installer
+Exec=calamares_polkit_wrapper # Reuse the wrapper for privilege escalation
+Icon=calamares
+Terminal=false
+X-KDE-Autostart-Phase=Setup # Ensures it starts at an appropriate time
+"""
+        calamares_autostart_file_path: Path = autostart_dir_chroot / "calamares-zforge-autostart.desktop"
+        calamares_autostart_file_path.write_text(calamares_autostart_content)
+        self.logger.info(f"Calamares autostart .desktop file created at {calamares_autostart_file_path}")
+        self.logger.info("Live KDE desktop environment setup for Calamares completed.")
+
 
     def _create_calamares_launcher(self) -> None:
         """
-        Create a .desktop file for launching Calamares from the XFCE desktop
-        or application menu in the live environment.
+        Create a .desktop file for launching Calamares from the KDE Plasma desktop
+        or application menu in the live environment. This is a fallback if autostart fails or is disabled.
         """
-        self.logger.info("Creating Calamares desktop launcher...")
+        self.logger.info("Creating Calamares desktop launcher for KDE...")
 
-        # Content for the .desktop file.
-        # Exec=pkexec calamares: Runs Calamares with root privileges using polkit.
-        # This assumes polkit is configured to allow this without password in live session.
-        # An alternative is `sudo calamares` or running Calamares directly if the
-        # entire desktop session runs as root (as configured by auto-login).
-        # If session is root, `Exec=calamares` might be enough. `pkexec` is safer if not root session.
-        # Given autologin-user=root, `Exec=calamares` should be fine.
-        # However, `pkexec calamares` is a common way Calamares is launched.
         calamares_launcher_content: str = f"""[Desktop Entry]
 Type=Application
 Version=1.0
 Name=Install Z-Forge Proxmox VE
 Comment=Install Z-Forge Proxmox VE to your hard disk
-Exec=calamares_polkit_wrapper # Use a wrapper for pkexec or direct sudo
-Icon=calamares # Calamares usually installs an icon
+Exec=calamares_polkit_wrapper
+Icon=calamares
 Terminal=false
 StartupNotify=true
-Categories=System;
+Categories=System;Application; # Standard categories for system tools
+Keywords=Installer;Z-Forge;Proxmox;
 """
-        # Create a wrapper script for launching Calamares with privileges
-        # This avoids issues with pkexec directly in .desktop file sometimes or provides flexibility
+        # Wrapper script (re-ensure it's created, content can be the same as before)
         calamares_wrapper_script_path_chroot = self.chroot_path / "usr/bin/calamares_polkit_wrapper"
-        calamares_wrapper_script_content = """#!/bin/bash
-# Wrapper to launch Calamares, ensuring it runs with root privileges.
-# Tries pkexec first, falls back to gksudo/kdesudo (if available), then direct sudo.
+        if not calamares_wrapper_script_path_chroot.exists():
+            calamares_wrapper_script_content = """#!/bin/bash
 if command -v pkexec >/dev/null 2>&1; then
     pkexec calamares
-elif command -v gksudo >/dev/null 2>&1; then
-    gksudo calamares
-elif command -v kdesudo >/dev/null 2>&1; then
-    kdesudo calamares
+elif command -v kdesu >/dev/null 2>&1; then # kdesu is more KDE-native than gksudo
+    kdesu calamares
 elif command -v sudo >/dev/null 2>&1; then
     sudo calamares
 else
-    # Fallback if no privilege escalation tool is found, try direct (might fail if not root)
     calamares
 fi
 """
-        calamares_wrapper_script_path_chroot.write_text(calamares_wrapper_script_content)
-        calamares_wrapper_script_path_chroot.chmod(0o755)
-        self.logger.info(f"Calamares wrapper script created at {calamares_wrapper_script_path_chroot}")
+            calamares_wrapper_script_path_chroot.write_text(calamares_wrapper_script_content)
+            calamares_wrapper_script_path_chroot.chmod(0o755)
+            self.logger.info(f"Calamares wrapper script created/verified at {calamares_wrapper_script_path_chroot}")
 
-
-        # Path for the .desktop file in system applications directory.
         applications_dir_chroot: Path = self.chroot_path / "usr/share/applications"
         applications_dir_chroot.mkdir(parents=True, exist_ok=True)
         calamares_desktop_file_path: Path = applications_dir_chroot / "calamares-zforge.desktop"
         calamares_desktop_file_path.write_text(calamares_launcher_content)
-        self.logger.info(f"Calamares .desktop file created at {calamares_desktop_file_path}")
+        self.logger.info(f"Calamares .desktop file for KDE created at {calamares_desktop_file_path}")
 
-        # Optionally, copy the .desktop file to the root user's Desktop for easy access.
-        # This assumes the live session user is root, as configured in _setup_live_desktop_environment.
+        # KDE places desktop icons in ~/Desktop or what's configured by kdeglobals.
+        # For root user, this is typically /root/Desktop.
         root_desktop_dir_chroot: Path = self.chroot_path / "root/Desktop"
         root_desktop_dir_chroot.mkdir(parents=True, exist_ok=True)
+        # Ensure the target path for shutil.copy is the full file name
         shutil.copy(calamares_desktop_file_path, root_desktop_dir_chroot / "Install_Z-Forge.desktop")
-        self.logger.info(f"Calamares launcher copied to root's Desktop at {root_desktop_dir_chroot}")
-        self.logger.info("Calamares desktop launcher creation completed.")
+        self.logger.info(f"Calamares launcher copied to root's Desktop for KDE at {root_desktop_dir_chroot}")
+        self.logger.info("Calamares KDE desktop launcher creation completed.")
+
 
     def _get_calamares_version(self) -> str:
         """

--- a/builder/modules/kde_theme_config.py
+++ b/builder/modules/kde_theme_config.py
@@ -1,0 +1,258 @@
+import subprocess
+from pathlib import Path
+import logging
+
+class KDEThemeConfig:
+    def __init__(self, workspace: Path, config: dict):
+        self.workspace = workspace
+        self.config = config
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.chroot_path = workspace / "chroot"
+
+    def execute(self):
+        self.logger.info("Configuring KDE dark theme and conditional SDDM start...")
+
+        # Create a script to be run by systemd to check for headless boot
+        self._create_sddm_override_script()
+        # Create KDE global theme configuration
+        self._configure_kde_dark_theme()
+        # Create script to apply theme for root user if not already globally set
+        self._create_user_kde_theme_script()
+
+        # Enable a service that will run the SDDM override script
+        self._enable_sddm_override_service()
+
+        return {'status': 'success'}
+
+    def _create_sddm_override_script(self):
+        """
+        Creates a script that checks for a 'headless' kernel parameter.
+        If 'headless' is present, it disables SDDM.
+        Otherwise, it ensures SDDM is enabled.
+        Also, applies dark theme settings.
+        """
+        script_content = """#!/bin/bash
+# This script checks for 'headless=true' or 'zforge.headless=true' kernel parameter.
+# If found, it ensures SDDM is not started. Otherwise, it ensures SDDM is started.
+# It also applies KDE dark theme settings.
+
+HEADLESS_BOOT=false
+if grep -q -E '(^| )headless=true( |$)' /proc/cmdline || grep -q -E '(^| )zforge.headless=true( |$)' /proc/cmdline; then
+    HEADLESS_BOOT=true
+fi
+
+if [ "$HEADLESS_BOOT" = true ]; then
+    echo "Headless boot detected, disabling SDDM."
+    systemctl disable sddm.service
+    systemctl stop sddm.service || true # Try to stop if running, ignore error if not
+else
+    echo "Normal boot detected, ensuring SDDM is enabled."
+    systemctl enable sddm.service
+    # SDDM should be started by its own service dependencies if enabled
+fi
+
+# Apply KDE dark theme settings globally if possible, or for the root user
+# This part might be better handled by placing config files directly,
+# but we can also try to use kwriteconfig5 if available in chroot.
+
+# Global theme settings (might require root and specific paths)
+# These are usually set per-user, but we can try to set system-wide defaults.
+# The actual application of themes for the logged-in user happens via KDE's mechanisms.
+# We will primarily rely on placing config files.
+
+# The actual theme application for the live user (root) will be handled by
+# a script in /root/.config/plasma-workspace/env/ or similar.
+# This script focuses on SDDM behavior.
+"""
+        script_path = self.chroot_path / "usr/local/bin/zforge_sddm_theme_manager.sh"
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text(script_content)
+        script_path.chmod(0o755)
+        self.logger.info(f"SDDM override and theme manager script created at {script_path}")
+
+    def _configure_kde_dark_theme(self):
+        """
+        Places KDE configuration files for a dark theme (Breeze Dark).
+        These files will act as system-wide defaults or be copied to user's .config.
+        """
+        self.logger.info("Configuring KDE dark theme files...")
+
+        # kdeglobals: Main theme settings
+        kdeglobals_content = """[KDE]
+LookFeelPackage=org.kde.breezedark.desktop
+
+[General]
+ColorScheme=BreezeDark
+Name=BreezeDark
+shadeSortColumn=true
+widgetStyle=Breeze
+
+[Icons]
+Theme=breeze-dark
+"""
+        kdeglobals_dir = self.chroot_path / "etc/xdg"
+        kdeglobals_dir.mkdir(parents=True, exist_ok=True)
+        (kdeglobals_dir / "kdeglobals").write_text(kdeglobals_content)
+        self.logger.info(f"Global kdeglobals configured at {kdeglobals_dir / 'kdeglobals'}")
+
+        # Ensure the user's config directory will exist for the autostart/env script later
+        user_config_autostart = self.chroot_path / "root/.config/autostart-scripts" # For scripts run at login
+        user_config_env = self.chroot_path / "root/.config/plasma-workspace/env" # For scripts setting env vars
+        user_config_autostart.mkdir(parents=True, exist_ok=True)
+        user_config_env.mkdir(parents=True, exist_ok=True)
+
+
+    def _create_user_kde_theme_script(self):
+        """
+        Creates a script that runs when the root user logs into KDE.
+        This script ensures the dark theme is applied by copying global defaults
+        or using kwriteconfig5 if necessary.
+        """
+        # This script will be placed in /root/.config/plasma-workspace/env/ to be sourced,
+        # or /root/.config/autostart-scripts/ to be executed.
+        # Using autostart-scripts is generally safer for commands.
+
+        script_content = """#!/bin/bash
+# Apply KDE dark theme for the current user (root) if not already set
+
+# Path to user's kdeglobals
+USER_KDEGLOBALS_DIR="$HOME/.config"
+USER_KDEGLOBALS_FILE="$USER_KDEGLOBALS_DIR/kdeglobals"
+
+# Path to system-wide kdeglobals (fallback)
+SYSTEM_KDEGLOBALS_FILE="/etc/xdg/kdeglobals"
+
+# Create user config dir if it doesn't exist
+mkdir -p "$USER_KDEGLOBALS_DIR"
+
+# If user kdeglobals doesn't exist or is missing LookFeelPackage, copy from system default
+if [ ! -f "$USER_KDEGLOBALS_FILE" ] || ! grep -q "LookFeelPackage=org.kde.breezedark.desktop" "$USER_KDEGLOBALS_FILE"; then
+    if [ -f "$SYSTEM_KDEGLOBALS_FILE" ]; then
+        cp "$SYSTEM_KDEGLOBALS_FILE" "$USER_KDEGLOBALS_FILE"
+        echo "Applied system default kdeglobals to user."
+    else
+        # Fallback to kwriteconfig5 if system file not found (should not happen with previous step)
+        # Ensure kwriteconfig5 is available if this path is taken.
+        if command -v kwriteconfig5 > /dev/null; then
+            kwriteconfig5 --file "$USER_KDEGLOBALS_FILE" --group KDE --key LookFeelPackage org.kde.breezedark.desktop
+            kwriteconfig5 --file "$USER_KDEGLOBALS_FILE" --group General --key ColorScheme BreezeDark
+            kwriteconfig5 --file "$USER_KDEGLOBALS_FILE" --group General --key widgetStyle Breeze
+            kwriteconfig5 --file "$USER_KDEGLOBALS_FILE" --group Icons --key Theme breeze-dark
+            echo "Applied dark theme using kwriteconfig5."
+        else
+            echo "kwriteconfig5 command not found. Cannot apply theme programmatically."
+        fi
+    fi
+fi
+
+# Additional theme settings (example for Konsole)
+KONSOLE_PROFILE_DIR="$HOME/.local/share/konsole"
+mkdir -p "$KONSOLE_PROFILE_DIR"
+KONSOLE_PROFILE_FILE="$KONSOLE_PROFILE_DIR/BreezeDarkZForge.profile" # Custom profile name
+if [ ! -f "$KONSOLE_PROFILE_FILE" ]; then
+    echo "[Appearance]" > "$KONSOLE_PROFILE_FILE"
+    echo "ColorScheme=Breeze" >> "$KONSOLE_PROFILE_FILE" # Breeze scheme is dark in Breeze Dark theme
+    echo "" >> "$KONSOLE_PROFILE_FILE"
+    echo "[General]" >> "$KONSOLE_PROFILE_FILE"
+    echo "Name=BreezeDarkZForge" >> "$KONSOLE_PROFILE_FILE"
+    echo "Parent=FALLBACK/" >> "$KONSOLE_PROFILE_FILE"
+
+    # Set as default Konsole profile
+    KONSOLERC_FILE="$HOME/.config/konsolerc"
+    if command -v kwriteconfig5 > /dev/null; then
+        kwriteconfig5 --file "$KONSOLERC_FILE" --group "Desktop Entry" --key DefaultProfile "BreezeDarkZForge.profile"
+        echo "Set BreezeDarkZForge as default Konsole profile."
+    else
+        # Manual setting if kwriteconfig5 is not there
+        if [ -f "$KONSOLERC_FILE" ]; then
+            if grep -q "DefaultProfile=" "$KONSOLERC_FILE"; then
+                sed -i 's/DefaultProfile=.*/DefaultProfile=BreezeDarkZForge.profile/' "$KONSOLERC_FILE"
+            else
+                echo "DefaultProfile=BreezeDarkZForge.profile" >> "$KONSOLERC_FILE"
+            fi
+        else
+            echo "[Desktop Entry]" > "$KONSOLERC_FILE"
+            echo "DefaultProfile=BreezeDarkZForge.profile" >> "$KONSOLERC_FILE"
+        fi
+    fi
+fi
+"""
+        # Place it in autostart-scripts to be executed
+        script_path = self.chroot_path / "root/.config/autostart-scripts/apply_zforge_theme.sh"
+        script_path.parent.mkdir(parents=True, exist_ok=True) # Ensure parent dir
+        script_path.write_text(script_content)
+        script_path.chmod(0o755)
+        self.logger.info(f"User KDE theme application script created at {script_path}")
+
+
+    def _enable_sddm_override_service(self):
+        """
+        Creates and enables a systemd service to run the SDDM override script at boot.
+        """
+        service_content = f"""[Unit]
+Description=Z-Forge SDDM and Theme Manager
+DefaultDependencies=no
+After=local-fs.target systemd-logind.service # Run after filesystems are up and before login manager typically starts
+Before=display-manager.service sddm.service getty.target graphical.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/zforge_sddm_theme_manager.sh
+StandardOutput=journal+console
+StandardError=journal+console
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target graphical.target
+"""
+        service_path = self.chroot_path / "etc/systemd/system/zforge-sddm-theme-manager.service"
+        service_path.parent.mkdir(parents=True, exist_ok=True)
+        service_path.write_text(service_content)
+        self.logger.info(f"Z-Forge SDDM/Theme Manager service file created at {service_path}")
+
+        # Enable the service (this creates a symlink in the chroot's systemd preset dir)
+        # The actual enabling is done by systemctl enable in chroot or by systemd preset mechanisms.
+        # For now, just placing the file is enough. It will be enabled if systemd is told to.
+        # We can also explicitly enable it here.
+        try:
+            subprocess.run(
+                ["chroot", str(self.chroot_path), "systemctl", "enable", "zforge-sddm-theme-manager.service"],
+                check=True, capture_output=True, text=True
+            )
+            self.logger.info("zforge-sddm-theme-manager.service enabled successfully.")
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"Failed to enable zforge-sddm-theme-manager.service: {e.stderr}")
+            # This might not be critical if build system handles presets later.
+
+def add_kde_theme_module_to_build(builder_instance):
+    """
+    Helper function to instantiate and execute the KDEThemeConfig module.
+    This function would be called from the main builder script.
+    """
+    kde_theme_config = KDEThemeConfig(builder_instance.workspace, builder_instance.config)
+    result = kde_theme_config.execute()
+    if result['status'] == 'error':
+        raise Exception(f"KDEThemeConfig module failed: {result.get('error', 'Unknown error')}")
+    logging.info("KDEThemeConfig module executed successfully.")
+
+"""
+To integrate this module into the Z-Forge build process:
+
+1.  Save this code as `builder/modules/kde_theme_config.py`.
+2.  In the main builder script (e.g., `builder/z-forge.py` or wherever modules are loaded):
+    - Import `KDEThemeConfig` from this file.
+    - Instantiate `KDEThemeConfig` with `workspace` and `config`.
+    - Call its `execute()` method at an appropriate stage, likely after `LiveEnvironment`
+      and `CalamaresIntegration` but before `ISOGeneration`.
+    - Ensure the module is listed in `build_spec.yml` if module loading is dynamic:
+      ```yaml
+      modules:
+        # ... other modules
+        - name: KDEThemeConfig
+          enabled: true
+        # ... other modules
+      ```
+3.  Ensure `kwriteconfig5` (from `kwriteconfig` package) and `plasma-desktop` (for `org.kde.breezedark.desktop`)
+    are installed in the chroot. `kde-standard` should cover this.
+    The `live_environment.py` already adds `kde-standard`.
+"""

--- a/builder/modules/live_environment.py
+++ b/builder/modules/live_environment.py
@@ -81,10 +81,12 @@ class LiveEnvironment:
             'rsync',
             'cryptsetup',
             'lvm2',
-            'mdadm'
+            'mdadm',
+            'kde-standard',  # Added KDE standard packages
+            'sddm'           # Added SDDM display manager
         ]
 
-        install_cmd = f"apt-get install -y {' '.join(packages)}"
+        install_cmd = f"apt-get install -y --no-install-recommends {' '.join(packages)}" # Added --no-install-recommends
 
         subprocess.run(
             ["chroot", str(self.chroot_path), "bash", "-c", install_cmd],
@@ -174,7 +176,7 @@ iface lo inet loopback
         services_to_enable = [
             'NetworkManager',
             'ssh',  # For remote debugging
-            'lightdm'
+            'sddm'  # Changed lightdm to sddm
         ]
 
         for service in services_to_enable:
@@ -196,21 +198,26 @@ iface lo inet loopback
             )
 
         # Create custom installer service
-        installer_service = """[Unit]
-Description=Z-Forge Installer
-After=graphical.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/calamares
-RemainAfterExit=yes
-
-[Install]
-WantedBy=graphical.target
-"""
-
+        # installer_service = """[Unit]
+# Description=Z-Forge Installer
+# After=graphical.target
+#
+# [Service]
+# Type=oneshot
+# ExecStart=/usr/bin/calamares
+# RemainAfterExit=yes
+#
+# [Install]
+# WantedBy=graphical.target
+# """
+        # service_path = self.chroot_path / "etc/systemd/system/zforge-installer.service"
+        # service_path.write_text(installer_service)
+        # Ensure the service file is removed if it exists from previous versions
         service_path = self.chroot_path / "etc/systemd/system/zforge-installer.service"
-        service_path.write_text(installer_service)
+        if service_path.exists():
+            service_path.unlink()
+            self.logger.info(f"Removed existing service file: {service_path}")
+
 
     def _generate_initramfs(self):
         """Generate initramfs for live boot"""


### PR DESCRIPTION
…boot

This commit introduces the following changes:

- Modified `live_environment.py` to install `kde-standard` and `sddm`, and switched the default display manager service from LightDM to SDDM.
- Updated `calamares_integration.py` to configure a KDE Plasma (X11) session with SDDM, including auto-login for the root user and Calamares autostart. Removed XFCE/LightDM specific configurations.
- Created `kde_theme_config.py`, a new build module to:
    - Configure KDE Plasma to use the Breeze Dark theme globally and for the root user.
    - Implement a systemd service (`zforge-sddm-theme-manager.service`) that checks for a `headless=true` or `zforge.headless=true` kernel parameter.
    - If headless mode is detected, the service disables SDDM, allowing the system to boot to the command line. Otherwise, SDDM is enabled.
- Integrated the `KDEThemeConfig` module into the main build process in `builder/core/builder.py` by ensuring modules are loaded dynamically from the `builder/modules` directory.
- Updated `build_spec.yml` to include `KDEThemeConfig` in the list of modules to be executed and added necessary packages (`kwriteconfig5`, `breeze`, `plasma-desktop-data`) for theme configuration.

These changes allow the Z-Forge live environment to boot into a KDE Plasma desktop with a dark theme by default. It also provides the option for a headless boot (no GUI) by specifying a kernel parameter, which is useful for server environments or specific debugging scenarios.